### PR TITLE
1，修复多页面切换，page为全局变量，导致一个页面page出现跳跃情况

### DIFF
--- a/app/src/main/resources/static/js/collect.js
+++ b/app/src/main/resources/static/js/collect.js
@@ -885,7 +885,8 @@ $(function() {
 	var loadingFlag = true;
 
 	$(window).scroll(function() {
-		if ($(window).scrollTop() == $(document).height() - $(window).height()) {
+        //当前页面剩40px加载完时，预加载下一页，使翻页更平滑
+        if ( $(document).height() - $(window).height() -$(window).scrollTop() < 40 ) {
             if ($('#lookAround').length >= 1) {
                 if ($('#standard').is(':visible')) {
                     if ($('#loadStandardMore').text() == '加载更多') {

--- a/app/src/main/resources/static/js/comm.js
+++ b/app/src/main/resources/static/js/comm.js
@@ -73,7 +73,11 @@ function getFileName(param){
 	　　}
 
 function locationUrl(url,activeId){
-	if(mainActiveId != null && mainActiveId != "" && activeId != null && activeId != ""){
+    //每次跳转切换页面时，设置该页面page=1
+    page =1;
+    //滚动条设置为页面顶部。不设置的话，假设第一个页面加载了10页，第二个页面切换过去后，由于滚动条在下边，会一直加载10页才停止
+    window.scrollTo(0,0);
+    if(mainActiveId != null && mainActiveId != "" && activeId != null && activeId != ""){
 		$("#"+mainActiveId).removeAttr("class");
 		$("#"+activeId).attr("class", "active");
 		mainActiveId = activeId;


### PR DESCRIPTION
2，优化滚动翻页，提前预加载。切换页面后锚点到最上边，防止第一个页面加载10多页，切换页面第二个页面直接预加载10